### PR TITLE
We don't want aggregations by ISP for the regular map.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -281,7 +281,7 @@ var geoLayers = {
 	'census_block_groups': {
 		'name': 'Census block groups',
 		'polygonFile': 'seattle_census10_blockgroups.topojson',
-		'dataUrl': 'stats/q/by_census_block?format=json&stats=AverageRTT,DownloadCount,MedianDownload,AverageDownload,UploadCount,MedianUpload,AverageUpload&b.isp_bins&b.spatial_join=key&b.time_slices=month&f.time_slices=',
+		'dataUrl': 'stats/q/by_census_block?format=json&stats=AverageRTT,DownloadCount,MedianDownload,AverageDownload,UploadCount,MedianUpload,AverageUpload&b.spatial_join=key&b.time_slices=month&f.time_slices=',
 		'dbKey': 'geoid10',
 		'geoKey': 'GEOID10',
 		'cache': null,
@@ -290,7 +290,7 @@ var geoLayers = {
 	'council_districts': {
 		'name': 'Council districts',
 		'polygonFile': 'seattle_council_districts.topojson',
-		'dataUrl': 'stats/q/by_council_district?format=json&stats=AverageRTT,DownloadCount,MedianDownload,AverageDownload,UploadCount,MedianUpload,AverageUpload&b.isp_bins&b.spatial_join=key&b.time_slices=month&f.time_slices=',
+		'dataUrl': 'stats/q/by_council_district?format=json&stats=AverageRTT,DownloadCount,MedianDownload,AverageDownload,UploadCount,MedianUpload,AverageUpload&b.spatial_join=key&b.time_slices=month&f.time_slices=',
 		'dbKey': 'district',
 		'geoKey': 'district',
 		'cache': null,


### PR DESCRIPTION
I apparently added ISP binning to the Piecewise data URL in commit @a72c1d4.  This is bad because you then potentially get multiple records for a given polygon, but only one will be used, meaning the data is ultimately incomplete.
