### PR TITLE
Use new underlying values to create the bigquery_key compound key.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -184,6 +184,7 @@
 
 <script>
 	var ndtServer,
+		ndtServerIp,
 		ndtPort = "3001",
 		ndtPath = "/ndt_protocol",
 		ndtUpdateInterval = 1000,
@@ -246,6 +247,7 @@
 			if (xhr.readyState === 4) {
 				if (xhr.status === 200) {
 					ndtServer = JSON.parse(xhr.responseText).fqdn;
+					ndtServerIp = JSON.parse(xhr.responseText).ip;
 					console.log('Using M-Lab Server ' + ndtServer);
 				} else {
 					console.log('M-Lab NS lookup failed.');

--- a/html/js/ndt_d3.js
+++ b/html/js/ndt_d3.js
@@ -144,9 +144,8 @@ NDTmeter.prototype.onfinish = function (passed_results) {
     'MinRTT': 'Latency'
   };
 
-  document.getElementById('bigquery_key').value = passed_results['Duration'] +
-      passed_results['CountRTT'] + passed_results['PktsIn'] +
-      passed_results['PktsOut'];
+  document.getElementById('bigquery_key').value =
+    passed_results['StartTimeUsec'] + window.ndtServerIp
 
   for (metric_name in results_to_display) {
     if (results_to_display.hasOwnProperty(metric_name)  &&


### PR DESCRIPTION
The Web100 data from which we were construction the compound bigquery_key field before turned out to not match the data that clients have/receive after an NDT test is run, so was not usable as a way of correlating M-Lab test results with the test results in the piecewise "extra_data" table. This PR changes the underlying values on which the bigquery_key field is derived.
